### PR TITLE
don't default to nonroot user to allow easier dynamic package management

### DIFF
--- a/.apko.yaml
+++ b/.apko.yaml
@@ -1,12 +1,3 @@
-accounts:
-  groups:
-    - groupname: nonroot
-      gid: 65532
-  users:
-    - username: nonroot
-      uid: 65532
-  run-as: 65532
-
 contents:
   repositories:
     - https://dl-cdn.alpinelinux.org/alpine/edge/main


### PR DESCRIPTION
since this is just a dev container, remove defaulting to `nonroot` to allow users to update packages without a rebuild